### PR TITLE
Sourcemap grunt task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ run-router:
 	export grumman=${PORT}; export PORT=5050; export DEBUG=proxy ; next-router
 
 build:
-	export ENVIRONMENT=development; ./node_modules/.bin/gulp
+	export ENVIRONMENT=development; ./node_modules/.bin/gulp; ./node_modules/.bin/gulp sourcemap
 
 build-production:
 	@bower install

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ run-router:
 	export grumman=${PORT}; export PORT=5050; export DEBUG=proxy ; next-router
 
 build:
-	export ENVIRONMENT=development; ./node_modules/.bin/gulp; ./node_modules/.bin/gulp sourcemap
+	export ENVIRONMENT=development; ./node_modules/.bin/gulp build-dev;
 
 build-production:
 	@bower install
-	@gulp
+	@gulp build-prod
 
 watch:
 	@gulp watch

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,22 +58,20 @@ gulp.task('build', function () {
 		sass: './client/main.scss',
 		js: './client/main.js',
 		buildFolder: './public',
-		env: process.env.ENVIRONMENT || 'production',
-		sourcemaps : true,
-		compress : {js:false, scss:true}
+		env: 'development'
 	});
 });
 
-gulp.task('minify-js',['build', 'sourcemap'], function(){
-	return gulp.src([mainJsFile])
+gulp.task('minify-js',['build'], function(){
+	return gulp.src(mainJsFile)
 		.pipe(sourcemaps.init({loadMaps:true}))
 			.pipe(concat(mainJsFile))
 			.pipe(uglify())
-		.pipe(sourcemaps.write('./'))
-		.pipe(gulp.dest('./public/'));
+		.pipe(sourcemaps.write())
+		.pipe(gulp.dest('.'))
 });
 
-gulp.task('sourcemap', ['build'], function(){
+gulp.task('sourcemap', ['build', 'minify-js'], function(){
 	return gulp.src(mainJsFile)
 		.pipe(gulpSourcemapExtration({app:'grumman'}))
 		.pipe(gulp.dest('./public/'));
@@ -83,7 +81,7 @@ gulp.task('watch', function() {
 	gulp.watch('./client/**/*', ['default']);
 });
 
-gulp.task('build-dev', ['build', 'sourcemap']);
-gulp.task('build-prod', ['build', 'sourcemap', 'minify-js']);
+gulp.task('build-dev', ['build']);
+gulp.task('build-prod', ['build', 'minify-js', 'sourcemap']);
 
 gulp.task('default', ['build-dev']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,40 +10,17 @@ var obt = require('origami-build-tools');
 var through = require('through2');
 var fs = require('fs');
 
-
-function gulpSourcemapExtration(opt){
-	var app  = opt.app,
-		filePathTransformationRegex = new RegExp('^.+/next-' + app, 'i');
-
-
-	function transformFilePath(path){
-		return path.replace(filePathTransformationRegex, '/' + app);
-	}
+function fixSourcemapUrl(opt){
+	var app = opt.app;
 
 	function extract(file, enc, cb){
 		if (file.isNull()) return cb(null, file);
-		if (file.isStream()) return cb(new PluginError('gulp-coffee', 'Streaming not supported'));
-
-		//var regex = new RegExp('^\/\/# sourceMappingURL=data:application\/json;base64(.+)$'),
-		var regex = /^\/\/# sourceMappingURL=data:application\/json;base64,(.+)$/m,
-			contents = file.contents.toString('utf8'),
-			newContents = contents.replace(regex, "//# sourceMappingURL=/" + app + "/main.js.map"),
-			results = regex.exec(contents),
-			sourcemapStr,
-			sourcemapObj
-
-		if(results && results.length > 1){
-			sourcemapStr = new Buffer(results[1], 'base64').toString('utf8');
-			sourcemapObj = JSON.parse(sourcemapStr);
-			sourcemapObj.sources = sourcemapObj.sources.map(transformFilePath);
-			fs.writeFile(jsSourcemapFile, JSON.stringify(sourcemapObj), function(){
-				file.contents = new Buffer(newContents);
-				cb(null, file);
-			});
-			return;
-		}
-
-		cb(new Error("Failed to parse out sourcemap"), null);
+		if (file.isStream()) return cb(new PluginError('gulp-sourcemapfixed', 'Streaming not supported'));
+		var regex = new RegExp('^(//# sourceMappingURL=)(.+)/(main.js.map)$', 'm');
+		var contents = file.contents.toString('utf8');
+		var newContents = contents.replace(regex, "$1/" + app + "/$3");
+		file.contents = new Buffer(newContents);
+		cb(null, file);
 	}
 
 	return through.obj(extract);
@@ -67,13 +44,13 @@ gulp.task('minify-js',['build'], function(){
 		.pipe(sourcemaps.init({loadMaps:true}))
 			.pipe(concat(mainJsFile))
 			.pipe(uglify())
-		.pipe(sourcemaps.write())
+		.pipe(sourcemaps.write('.'))
 		.pipe(gulp.dest('.'))
 });
 
 gulp.task('sourcemap', ['build', 'minify-js'], function(){
 	return gulp.src(mainJsFile)
-		.pipe(gulpSourcemapExtration({app:'grumman'}))
+		.pipe(fixSourcemapUrl({app:'grumman'}))
 		.pipe(gulp.dest('./public/'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,19 +3,85 @@
 
 var gulp = require('gulp');
 require('gulp-watch');
+var uglify = require('gulp-uglify');
+var sourcemaps = require('gulp-sourcemaps');
 var obt = require('origami-build-tools');
+var through = require('through2');
+var fs = require('fs');
+
+
+function gulpSourcemapExtration(opt){
+	var app  = opt.app,
+		filePathTransformationRegex = new RegExp('^.+/next-' + app, 'i');
+
+
+	function transformFilePath(path){
+		return path.replace(filePathTransformationRegex, '/' + app);
+	}
+
+	function extract(file, enc, cb){
+		if (file.isNull()) return cb(null, file);
+		if (file.isStream()) return cb(new PluginError('gulp-coffee', 'Streaming not supported'));
+
+		//var regex = new RegExp('^\/\/# sourceMappingURL=data:application\/json;base64(.+)$'),
+		var regex = /^\/\/# sourceMappingURL=data:application\/json;base64,(.+)$/m,
+			contents = file.contents.toString('utf8'),
+			newContents = contents.replace(regex, "//# sourceMappingURL=/" + app + "/main.js.map"),
+			results = regex.exec(contents),
+			sourcemapStr,
+			sourcemapObj
+
+		if(results && results.length > 1){
+			sourcemapStr = new Buffer(results[1], 'base64').toString('utf8');
+			sourcemapObj = JSON.parse(sourcemapStr);
+			sourcemapObj.sources = sourcemapObj.sources.map(transformFilePath);
+			fs.writeFile(jsSourcemapFile, JSON.stringify(sourcemapObj), function(){
+				file.contents = new Buffer(newContents);
+				cb(null, file);
+			});
+			return;
+		}
+
+		cb(new Error("Failed to parse out sourcemap"), null);
+	}
+
+	return through.obj(extract);
+}
+
+var mainJsFile = './public/main.js';
+var jsSourcemapFile = './public/main.js.map';
+
 
 gulp.task('build', function () {
-	obt.build(gulp, {
+	return obt.build(gulp, {
 		sass: './client/main.scss',
 		js: './client/main.js',
 		buildFolder: './public',
-		env: process.env.ENVIRONMENT || 'production'
+		env: process.env.ENVIRONMENT || 'production',
+		sourcemaps : true,
+		compress : {js:false, scss:true}
 	});
+});
+
+gulp.task('minify-js',['build', 'sourcemap'], function(){
+	return gulp.src(mainJsFile)
+		.pipe(sourcemaps.init({loadMaps:true}))
+		.pipe(uglify({inSourceMap:jsSourcemapFile, outSourceMap:jsSourcemapFile}))
+		.pipe(sourcemaps.write('./public/'))
+		.pipe(gulp.dest('./public/'));
+});
+
+gulp.task('sourcemap', ['build'], function(){
+	return gulp.src(mainJsFile)
+		.pipe(gulpSourcemapExtration({app:'grumman'}))
+		.pipe(gulp.dest('./public/'));
 });
 
 gulp.task('watch', function() {
 	gulp.watch('./client/**/*', ['default']);
 });
 
-gulp.task('default', ['build']);
+gulp.task('build-dev', ['build', 'sourcemap']);
+gulp.task('build-prod', ['build', 'sourcemap', 'minify-js']);
+
+gulp.task('default', ['build-dev']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,17 +29,27 @@ function fixSourcemapUrl(opt){
 var mainJsFile = './public/main.js';
 var jsSourcemapFile = './public/main.js.map';
 
-
-gulp.task('build', function () {
-	return obt.build(gulp, {
+function getOBTConfig(env){
+	return {
 		sass: './client/main.scss',
 		js: './client/main.js',
 		buildFolder: './public',
-		env: 'development'
-	});
+		env: env
+	};
+}
+
+
+gulp.task('build-js', function () {
+	return obt.build.js(gulp, getOBTConfig('development'));
 });
 
-gulp.task('minify-js',['build'], function(){
+gulp.task('build-sass', function(){
+	return obt.build.sass(gulp, getOBTConfig(process.env.ENVIRONMENT || 'production'));
+});
+
+gulp.task('build', ['build-js', 'build-sass']);
+
+gulp.task('minify-js',['build-js'], function(){
 	return gulp.src(mainJsFile)
 		.pipe(sourcemaps.init({loadMaps:true}))
 			.pipe(concat(mainJsFile))
@@ -48,7 +58,7 @@ gulp.task('minify-js',['build'], function(){
 		.pipe(gulp.dest('.'))
 });
 
-gulp.task('sourcemap', ['build', 'minify-js'], function(){
+gulp.task('sourcemap', ['minify-js'], function(){
 	return gulp.src(mainJsFile)
 		.pipe(fixSourcemapUrl({app:'grumman'}))
 		.pipe(gulp.dest('./public/'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@
 
 var gulp = require('gulp');
 require('gulp-watch');
+var concat = require('gulp-concat');
 var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
 var obt = require('origami-build-tools');
@@ -64,10 +65,11 @@ gulp.task('build', function () {
 });
 
 gulp.task('minify-js',['build', 'sourcemap'], function(){
-	return gulp.src(mainJsFile)
+	return gulp.src([mainJsFile])
 		.pipe(sourcemaps.init({loadMaps:true}))
-		.pipe(uglify({inSourceMap:jsSourcemapFile, outSourceMap:jsSourcemapFile}))
-		.pipe(sourcemaps.write('./public/'))
+			.pipe(concat(mainJsFile))
+			.pipe(uglify())
+		.pipe(sourcemaps.write('./'))
 		.pipe(gulp.dest('./public/'));
 });
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
   "devDependencies": {
     "chai": "^1.9.2",
     "gulp": "^3.8.8",
+    "gulp-sourcemaps": "^1.3.0",
+    "gulp-uglify": "^1.0.2",
     "gulp-watch": "^1.0.7",
     "mocha": "^1.21.4",
     "nock": "^0.50.0",
     "origami-build-tools": "https://github.com/Financial-Times/origami-build-tools/archive/master.tar.gz",
     "request": "^2.44.0",
-    "sinon": "^1.12.1"
+    "sinon": "^1.12.1",
+    "through2": "^0.6.3"
   },
   "engines": {
     "node": "0.10.x"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "chai": "^1.9.2",
     "gulp": "^3.8.8",
+    "gulp-concat": "^2.4.3",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.0.2",
     "gulp-watch": "^1.0.7",


### PR DESCRIPTION
Ok, it works this time - it is a riduculous solution, but it works.

Bascially, we need run origami build tools, then do the minification ourselved, using the grunt-sourcemaps plugin to create the new sourcemap.

Unfortunately, grunt-sourcemaps does some weird stuff with paths so we save the new sourcemap inline, then extract it back out, transform all the paths to match the app and chuck it in a separate file.

Once this is merged I can verify it works in production and that sentry can use it, before attempting to either apply this across all the apps or get it into origami-build-tools