### PR TITLE
switch access to middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -19,8 +19,7 @@ app.get('/', function(req, res) {
 	res.redirect('/search?q=page:Front%20page');
 });
 
-// The Access endpoint calls this to establish content classification
-app.head(/^\/([a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+)/, require('./controllers/access'));
+app.use(/^\/([a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+)/, require('./controllers/access'));
 
 app.get(/^\/fastft\/([0-9]+)(\/[\w\-])?/, require('./controllers/fastft'));
 app.get(/^\/([a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+\-[a-f0-9]+)\/main-image/, require('./controllers/capi-main-image'));

--- a/server/controllers/access.js
+++ b/server/controllers/access.js
@@ -1,9 +1,7 @@
 /*jshint node:true*/
 'use strict';
-var Metrics = require('next-metrics');
 
 module.exports = function(req, res, next) {
-	Metrics.instrument(res, { as: 'express.http.res' });
 	var apiKey = res.locals.flags.articlesFromContentApiV2.isSwitchedOn ? process.env.apikey : process.env.api2key;
 	var api = require('ft-api-client')(apiKey);
 	if (req.get('X-FT-Access-Metadata') === 'remote_headers') {
@@ -15,6 +13,6 @@ module.exports = function(req, res, next) {
 			res.status(200).end();
 		}).catch(next);
 	} else {
-		res.status(400).end();
+		next();
 	}
 };

--- a/server/controllers/capi.js
+++ b/server/controllers/capi.js
@@ -52,8 +52,10 @@ module.exports = function(req, res, next) {
 	})
 		.then(fetchres.json)
 		.then(function(article) {
-			res.vary(['Accept-Encoding', 'Accept']);
+			res.vary(['Accept-Encoding', 'Accept', 'X-FT-UID']);
 			res.set(cacheControl);
+			res.set('X-FT-UID', article.id);
+			res.set('X-FT-Content-Classification', article.contentClassification);
 
 			switch(req.accepts(['html', 'json'])) {
 				case 'html':

--- a/server/controllers/capi.js
+++ b/server/controllers/capi.js
@@ -52,11 +52,8 @@ module.exports = function(req, res, next) {
 	})
 		.then(fetchres.json)
 		.then(function(article) {
-			res.vary(['Accept-Encoding', 'Accept', 'X-FT-UID']);
+			res.vary(['Accept-Encoding', 'Accept']);
 			res.set(cacheControl);
-			res.set('X-FT-UID', article.id);
-			res.set('X-FT-Content-Classification', article.contentClassification);
-
 			switch(req.accepts(['html', 'json'])) {
 				case 'html':
 					article.bodyXML = replaceEllipses(article.bodyXML);


### PR DESCRIPTION
It turns out that Fastly turns a HEAD request into a GET so switching to middleware and pivoting on the header field instead.