### PR TITLE
Article-related follow functionality 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "o-big-number": "Financial-Times/o-big-number#~1.0.0",
     "next-footer": "Financial-Times/next-footer#^1.3.3",
     "next-messaging": "https://github.com/Financial-Times/next-messaging.git#^1.0.0",
-    "o-gallery": "^1.6.1"
+    "o-gallery": "^1.6.1",
+    "next-buttons": "Financial-Times/next-buttons#~1.0.0-beta.7"
   }
 }

--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -15,7 +15,7 @@ $inline-img-width: 300px;
 	width: 100%;
 	height: 100%;
 	background-size: cover;
-	background-position: 0;
+	background-position: 50%;
 	-webkit-filter: blur(5px);
 	-moz-filter: blur(5px);
 	-o-filter: blur(5px);
@@ -81,28 +81,37 @@ $inline-img-width: 300px;
 		text-decoration: underline;
 	}
 }
+.article__actions {
+	text-align: right;
+}
 .article__timestamp,
 .article__actions__action {
 	font-weight: 400;
 	font-size: 12px;
 	text-transform: uppercase;
 }
-.article__actions {
-	text-align: right;
-}
 .article__actions__action {
 	color: inherit;
-	text-decoration: none;
 
-	&:hover {
-		text-decoration: underline;
-	}
 	&:before {
 		content: '|';
 		margin-right: 5px;
 	}
 	&:first-child:before {
 		display: none;
+	}
+}
+.article__actions__action--save {
+	background-color: transparent;
+	border: none;
+	padding: 0;
+	font-weight: inherit;
+	font-size: 12px;
+	font-family: inherit;
+
+	&:hover {
+		text-decoration: underline;
+		cursor: pointer;
 	}
 }
 .article__toc {

--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -1,11 +1,11 @@
 //VARIABLES
-$brand-offset: 30px;
+$header-offset: 30px;
 $inline-img-width: 300px;
 
-//ARTICLE COLOUR BRANDS
+//ARTICLE HEADER
 .article__header {
 	position: relative;
-	padding-bottom: $brand-offset + 20;
+	padding-bottom: $header-offset + 20;
 	background-color: #3b3e7f;
 	font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
 	font-weight: 100;
@@ -15,13 +15,19 @@ $inline-img-width: 300px;
 	width: 100%;
 	height: 100%;
 	background-size: cover;
+	background-position: 0;
+	-webkit-filter: blur(5px);
+	-moz-filter: blur(5px);
+	-o-filter: blur(5px);
+	-ms-filter: blur(5px);
+	filter: blur(5px);
 	opacity: 0.2;
 	position: absolute;
 	top: 0;
 	left: 0;
 }
 
-//ARTICLE ELEMENTS
+//ARTICLE META ELEMENTS
 .article__theme {
 	margin: 10px 0 0;
 }
@@ -44,7 +50,7 @@ $inline-img-width: 300px;
 	line-height: 1em;
 }
 .article__main-image {
-	margin-top: -$brand-offset;
+	margin-top: -$header-offset;
 }
 .article__stand-first {
 	margin: 20px 0 0;
@@ -56,7 +62,7 @@ $inline-img-width: 300px;
 .article__meta {
 	margin: 20px 0 0;
 }
-.article__authors {
+.article__byline {
 	margin: 0;
 	padding: 0;
 	font-weight: 400;
@@ -66,17 +72,14 @@ $inline-img-width: 300px;
 		font-size: 18px;
 	}
 }
-.article__authors__author {
+.article__author,
+.article__section {
 	color: inherit;
 	text-decoration: none;
 
 	&:hover {
 		text-decoration: underline;
 	}
-}
-.article__author__link {
-	color: inherit;
-	text-decoration: none;
 }
 .article__timestamp,
 .article__actions__action {
@@ -135,22 +138,6 @@ $inline-img-width: 300px;
 	}
 }
 
-//ARTICLE META ELEMENTS
-.article__byline {
-	margin-top: 10px;
-	margin-bottom: 10px;
-	display: block;
-	font-family: MetricWeb;
-	font-style: normal;
-	font-size: 14px;
-	line-height: 16px;
-	color: $next-grey-dark;
-
-	a {
-		font-weight: bold;
-		color: $next-grey-dark;
-	}
-}
 
 //ARTICLE BODY ELEMENTS
 .article__body {
@@ -179,6 +166,9 @@ $inline-img-width: 300px;
 
 	video {
 		width: 100%;
+	}
+	> .article__video:first-child {
+		margin-top: -$header-offset;
 	}
 }
 
@@ -218,6 +208,9 @@ $inline-img-width: 300px;
 		width: 24px;
 		height: 21px;
 	}
+}
+.article__rail-advert {
+	margin-top: 0.3em;
 }
 
 //++++++++++++++++++++++++++

--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -36,11 +36,11 @@ $inline-img-width: 300px;
 	font-size: 18px;
 	text-decoration: none;
 
-	&:hover {
-		text-decoration: underline;
-	}
 	@include oGridRespondTo(L) {
 		font-size: 22px;
+	}
+	&:hover {
+		text-decoration: underline;
 	}
 }
 .article__title {
@@ -103,7 +103,7 @@ $inline-img-width: 300px;
 }
 .article__actions__action--save {
 	background-color: transparent;
-	border: none;
+	border: 0;
 	padding: 0;
 	font-weight: inherit;
 	font-size: 12px;

--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -25,6 +25,18 @@ $inline-img-width: 300px;
 .article__theme {
 	margin: 10px 0 0;
 }
+.article__authors__link {
+	color: inherit;
+	font-size: 18px;
+	text-decoration: none;
+
+	&:hover {
+		text-decoration: underline;
+	}
+	@include oGridRespondTo(L) {
+		font-size: 22px;
+	}
+}
 .article__title {
 	margin: 20px 0 0;
 	font-size: 36px;

--- a/client/components/video/main.js
+++ b/client/components/video/main.js
@@ -32,6 +32,7 @@ function brightcoveInit(el) {
 			'//image.webservices.ft.com/v1/images/raw/' + encodeURIComponent(data.poster) + '?width=690&source=grumman&fit=scale-down'
 		);
 		videoEl.setAttribute('controls', 'true');
+		videoEl.className = 'article__video';
 		el.parentNode.replaceChild(videoEl, el);
 	}).catch(function(e){
 		el.parentNode.removeChild(el);

--- a/views/layout.html
+++ b/views/layout.html
@@ -2,11 +2,21 @@
 	<div class="article__header">
 		<div class="article__header__bg" style="background-image: url({{#resize 1400}}http://ft-next-grumman-v002.herokuapp.com/{{article.id}}/main-image{{/resize}})"></div>
 		<div class="o-grid-row">
-			<div data-o-grid-colspan="12 XLoffset2">
-				<p class="article__theme">
-					{{{articleV1.metadata.primaryTheme.term.name}}}
-				</p>
-			</div>
+			{{#with articleV1.metadata.primaryTheme}}
+				<div data-o-grid-colspan="12 XLoffset2">
+					<p class="article__theme">
+						<button
+							class="next-buttons--follow next-buttons--light"
+							data-concept-id="{{term.taxonomy}}:&quot;{{term.name}}&quot;"
+							data-trackable="follow"
+							data-user-prefs-button="follow"
+							data-alternate-label="Unfollow this topic"
+							aria-label="Follow this topic"
+							title="Follow this topic"></button>
+						{{term.name}}
+					</p>
+				</div>
+			{{/with}}
 			<div data-o-grid-colspan="12 L8 XL7 XLoffset2">
 				<h3 class="article__title">{{{article.titleHTML}}}</h3>
 			</div>
@@ -17,13 +27,20 @@
 				<div class="article__meta">
 					{{#if articleV1.metadata.authors.length}}
 						<p class="article__authors">
-							By
 							{{#each articleV1.metadata.authors}}
 								{{#ifAll @first @last}}{{else}}
 									{{#if @first}}{{else}}
 										{{#if @last}} and {{else}}, {{/if}}
 									{{/if}}
 								{{/ifAll}}
+								<button
+									class="next-buttons--follow next-buttons--light"
+									data-concept-id="authors:&quot;{{this.term.name}}&quot;"
+									data-trackable="follow"
+									data-user-prefs-button="follow"
+									data-alternate-label="Unfollow this author"
+									aria-label="Follow this author"
+									title="Follow this author"></button>
 								<a class="article__authors__author" href="/stream/authors/{{this.term.name}}">
 									{{this.term.name}}
 								</a>

--- a/views/layout.html
+++ b/views/layout.html
@@ -2,18 +2,13 @@
 	<div class="article__header">
 		<div class="article__header__bg" style="background-image: url({{#resize 1400}}http://ft-next-grumman-v002.herokuapp.com/{{article.id}}/main-image{{/resize}})"></div>
 		<div class="o-grid-row">
-			{{#with articleV1.metadata.primaryTheme}}
+			{{#with articleV1.metadata.primaryTheme.term}}
 				<div data-o-grid-colspan="12 XLoffset2">
 					<p class="article__theme">
-						<button
-							class="next-buttons--follow next-buttons--light"
-							data-concept-id="{{term.taxonomy}}:&quot;{{term.name}}&quot;"
-							data-trackable="follow"
-							data-user-prefs-button="follow"
-							data-alternate-label="Unfollow this topic"
-							aria-label="Follow this topic"
-							title="Follow this topic"></button>
-						{{term.name}}
+						{{>articles/follow-button this}}
+						<a class="article__authors__link" href="/stream/{{taxonomy}}/{{name}}">
+							{{name}}
+						</a>
 					</p>
 				</div>
 			{{/with}}
@@ -25,28 +20,37 @@
 			</div>
 			<div data-o-grid-colspan="12 L8 XL7 XLoffset2">
 				<div class="article__meta">
-					{{#if articleV1.metadata.authors.length}}
-						<p class="article__authors">
-							{{#each articleV1.metadata.authors}}
-								{{#ifAll @first @last}}{{else}}
-									{{#if @first}}{{else}}
-										{{#if @last}} and {{else}}, {{/if}}
-									{{/if}}
-								{{/ifAll}}
-								<button
-									class="next-buttons--follow next-buttons--light"
-									data-concept-id="authors:&quot;{{this.term.name}}&quot;"
-									data-trackable="follow"
-									data-user-prefs-button="follow"
-									data-alternate-label="Unfollow this author"
-									aria-label="Follow this author"
-									title="Follow this author"></button>
-								<a class="article__authors__author" href="/stream/authors/{{this.term.name}}">
-									{{this.term.name}}
+					<p class="article__authors">
+						{{#ifEquals articleV1.metadata.primarySection.term.name 'Columnists'}}
+							{{#with articleV1.metadata.authors.[0].term}}
+								{{>articles/follow-button this type='author'}}
+								<a class="article__authors__author" href="/stream/authors/{{name}}">
+									{{name}}
 								</a>
-							{{/each}}
-						</p>
-					{{/if}}
+							{{/with}}
+						{{else}}
+							{{#with articleV1.metadata.authors}}
+								By
+								{{#each this}}
+									{{#ifAll @first @last}}{{else}}
+										{{#if @first}}{{else}}
+											{{#if @last}} and {{else}}, {{/if}}
+										{{/if}}
+									{{/ifAll}}
+									<a class="article__authors__author" href="/stream/authors/{{this.term.name}}">
+										{{term.name}}
+									</a>
+								{{/each}}
+							{{else}}
+								{{#with ../articleV1.metadata.primarySection.term}}
+									{{>articles/follow-button this type='author'}}
+									<a class="article__authors__author" href="/stream/sections/{{name}}">
+										{{name}}
+									</a>
+								{{/with}}
+							{{/with}}
+						{{/ifEquals}}
+					</p>
 					<div class="o-grid-row">
 						<div data-o-grid-colspan="8">
 							<time data-o-component="o-date" class="o-date article__timestamp" datetime="{{#dateformat}}{{article.publishedDate}}{{/dateformat}}" data-o-date-js>

--- a/views/layout.html
+++ b/views/layout.html
@@ -20,11 +20,11 @@
 			</div>
 			<div data-o-grid-colspan="12 L8 XL7 XLoffset2">
 				<div class="article__meta">
-					<p class="article__authors">
+					<p class="article__byline">
 						{{#ifEquals articleV1.metadata.primarySection.term.name 'Columnists'}}
 							{{#with articleV1.metadata.authors.[0].term}}
 								{{>articles/follow-button this type='author'}}
-								<a class="article__authors__author" href="/stream/authors/{{name}}">
+								<a class="article__author" href="/stream/authors/{{name}}">
 									{{name}}
 								</a>
 							{{/with}}
@@ -37,14 +37,14 @@
 											{{#if @last}} and {{else}}, {{/if}}
 										{{/if}}
 									{{/ifAll}}
-									<a class="article__authors__author" href="/stream/authors/{{this.term.name}}">
+									<a class="article__author" href="/stream/authors/{{this.term.name}}">
 										{{term.name}}
 									</a>
 								{{/each}}
 							{{else}}
 								{{#with ../articleV1.metadata.primarySection.term}}
 									{{>articles/follow-button this type='author'}}
-									<a class="article__authors__author" href="/stream/sections/{{name}}">
+									<a class="article__section" href="/stream/sections/{{name}}">
 										{{name}}
 									</a>
 								{{/with}}

--- a/views/layout.html
+++ b/views/layout.html
@@ -58,8 +58,15 @@
 							</time>
 						</div>
 						<div class="article__actions" data-o-grid-colspan="4">
-							<!-- <a class="article__actions__action" href="">Save</a>
-							<a class="article__actions__action" href="">Share</a> -->
+							<button
+								class="article__actions__action article__actions__action--save"
+								data-content-id="{{article.id}}"
+								data-headline="{{headline}}"
+								data-user-prefs-button="saveForLater"
+								data-alternate-text="Saved">
+								<span class="next-buttons__text">Save</span>
+							</button>
+							<!-- <a class="article__actions__action" href="">Share</a> -->
 						</div>
 					</div>
 					{{#if showTOC}}

--- a/views/partials/articles/follow-button.html
+++ b/views/partials/articles/follow-button.html
@@ -1,0 +1,8 @@
+<button
+	class="next-buttons--follow next-buttons--light"
+	data-concept-id="{{taxonomy}}:&quot;{{name}}&quot;"
+	data-trackable="follow"
+	data-user-prefs-button="follow"
+	data-alternate-label="Unfollow this {{#if type}}{{type}}{{else}}topic{{/if}}"
+	aria-label="Follow this {{#if type}}{{type}}{{else}}topic{{/if}}"
+	title="Follow this {{#if type}}{{type}}{{else}}topic{{/if}}"></button>


### PR DESCRIPTION
On theme/section/author. Plus, different follow options depending on whether it's a columnist, section or standard piece

Also, use non-deprecated 'save for later' button

![screen shot 2015-03-10 at 17 06 11](https://cloud.githubusercontent.com/assets/74132/6580336/d1c7bf7a-c747-11e4-84dc-127d5300d6fc.jpeg)
