### PR TITLE
Inline elements tidy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,11 +10,12 @@
     "next-sass-setup": "https://github.com/Financial-Times/next-sass-setup.git#^5.0.0",
     "next-js-setup": "https://github.com/Financial-Times/next-js-setup.git#^1.3.0",
     "o-quote": "https://github.com/Financial-Times/o-quote.git#bogdis-design",
-    "o-big-number": "Financial-Times/o-big-number#~1.0.0",
+    "o-big-number": "Financial-Times/o-big-number#~1.1.0",
     "next-footer": "Financial-Times/next-footer#^1.3.3",
     "next-messaging": "https://github.com/Financial-Times/next-messaging.git#^1.0.0",
     "o-gallery": "^1.6.1",
     "next-buttons": "Financial-Times/next-buttons#~1.0.0-beta.7",
-    "o-forms": "^1.0.0-beta.8"
+    "o-forms": "^1.0.0-beta.8",
+    "o-colors": "~2.4.7"
   }
 }

--- a/client/_helpers.scss
+++ b/client/_helpers.scss
@@ -3,7 +3,7 @@
 	display: block;
 	margin: 35px auto;
 
-	@include oGridRespondTo(M) {
+	@include oGridRespondTo(S) {
 		@include box-sizing(border-box);
 		float: left;
 		clear: left;

--- a/client/_helpers.scss
+++ b/client/_helpers.scss
@@ -1,0 +1,18 @@
+// GRUMMAN HELPER CLASSES
+.ng-inline-element {
+	display: block;
+	margin: 35px auto;
+
+	@include oGridRespondTo(M) {
+		@include box-sizing(border-box);
+		float: left;
+		clear: left;
+		margin: 50px 50px 50px 0;
+		max-width: 300px;
+	}
+}
+.ng-pull-out {
+	@include oGridRespondTo(XL) {
+		margin-left: -200px;
+	}
+}

--- a/client/_mixins.scss
+++ b/client/_mixins.scss
@@ -1,0 +1,12 @@
+@mixin filter($funcs...) {
+	-webkit-filter: $funcs;
+	-moz-filter: $funcs;
+	-o-filter: $funcs;
+	-ms-filter: $funcs;
+	filter: $funcs;
+}
+@mixin box-sizing($value) {
+	-webkit-box-sizing: $value;
+	-moz-box-sizing: $value;
+	box-sizing: $value;
+}

--- a/client/_setup.scss
+++ b/client/_setup.scss
@@ -1,0 +1,1 @@
+@include oColorsSetUseCase(ng-brand, background, blue);

--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -2,6 +2,25 @@
 $header-offset: 30px;
 $inline-img-width: 300px;
 
+//GRUMMAN HELPERS
+.g-inline-element {
+	display: block;
+	margin: 35px auto;
+
+	@include oGridRespondTo(M) {
+		box-sizing: border-box;
+		float: left;
+		clear: left;
+		margin: 50px 50px 50px 0;
+		max-width: 300px;
+	}
+}
+.g-pull-out {
+	@include oGridRespondTo(XL) {
+		margin-left: -200px;
+	}
+}
+
 //ARTICLE HEADER
 .article__header {
 	position: relative;
@@ -128,31 +147,6 @@ $inline-img-width: 300px;
 	font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
 }
 
-.article__inline-image {
-	display: block;
-	margin: 35px auto;
-}
-
-@include oGridRespondTo(M) {
-	.o-big-number,
-	.article__inline-image {
-		float: left;
-		clear: left;
-		margin: 50px 50px 50px 0;
-	}
-
-	.o-big-number {
-		width: 300px;
-	}
-}
-
-@include oGridRespondTo(XL) {
-	.o-big-number,
-	.article__inline-image {
-		margin-left: -200px;
-	}
-}
-
 
 //ARTICLE BODY ELEMENTS
 .article__body {
@@ -197,9 +191,6 @@ $inline-img-width: 300px;
 	margin: 10px 10px 0 0;
 	max-width: 100%;
 }
-.article__pullquote {
-	display: block;
-}
 .article__gallery {
 	line-height: initial;
 }
@@ -224,6 +215,15 @@ $inline-img-width: 300px;
 		height: 21px;
 	}
 }
+.article__pull-quote {
+	width: 100%;
+
+	@include oGridRespondTo(L) {
+		@include oQuoteStandardBig;
+	}
+}
+
+
 .article__rail-advert {
 	margin-top: 0.3em;
 }
@@ -273,10 +273,6 @@ $inline-img-width: 300px;
 		padding-top: 0;
 	}
 	.article__img-inline-offset {
-		margin-left: -$inline-img-width/2;
-	}
-	.article__pullquote {
-		width: 780px;
 		margin-left: -$inline-img-width/2;
 	}
 }

--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -2,25 +2,6 @@
 $header-offset: 30px;
 $inline-img-width: 300px;
 
-//GRUMMAN HELPERS
-.g-inline-element {
-	display: block;
-	margin: 35px auto;
-
-	@include oGridRespondTo(M) {
-		box-sizing: border-box;
-		float: left;
-		clear: left;
-		margin: 50px 50px 50px 0;
-		max-width: 300px;
-	}
-}
-.g-pull-out {
-	@include oGridRespondTo(XL) {
-		margin-left: -200px;
-	}
-}
-
 //ARTICLE HEADER
 .article__header {
 	position: relative;
@@ -35,11 +16,7 @@ $inline-img-width: 300px;
 	height: 100%;
 	background-size: cover;
 	background-position: 50%;
-	-webkit-filter: blur(5px);
-	-moz-filter: blur(5px);
-	-o-filter: blur(5px);
-	-ms-filter: blur(5px);
-	filter: blur(5px);
+	@include filter(blur(5px));
 	opacity: 0.2;
 	position: absolute;
 	top: 0;
@@ -160,15 +137,6 @@ $inline-img-width: 300px;
 		display: block;
 	}
 
-	blockquote {
-		margin-top: 1.5em;
-		margin-bottom: 1.5em;
-
-		@include oGridRespondTo(XL) {
-			margin-left: -200px;
-		}
-	}
-
 	a {
 		color: $next-grey-dark;
 	}
@@ -185,18 +153,13 @@ $inline-img-width: 300px;
 	text-align: center;
 	padding: 10px 0;
 }
-.article__img-inline,
-.article__img-inline-offset {
-	float: left;
-	margin: 10px 10px 0 0;
-	max-width: 100%;
-}
 .article__gallery {
 	line-height: initial;
 }
-.ft-subhead {
+.article__subhead {
 	padding-right: 40px;
 	position: relative;
+	border-bottom: 1px solid black;
 
 	.back-top-top {
 		position: absolute;
@@ -215,9 +178,18 @@ $inline-img-width: 300px;
 		height: 21px;
 	}
 }
+.article__big-number,
 .article__pull-quote {
 	width: 100%;
-
+	margin-top: 1.5em;
+	margin-bottom: 1.5em;
+}
+.article__big-number {
+	@include oGridRespondTo(L) {
+		@include oBigNumberStandardBig;
+	}
+}
+.article__pull-quote {
 	@include oGridRespondTo(L) {
 		@include oQuoteStandardBig;
 	}
@@ -241,10 +213,6 @@ $inline-img-width: 300px;
 			line-height: 28px;
 		}
 	}
-	.article__img-inline,
-	.article__img-inline-offset {
-		max-width: $inline-img-width;
-	}
 }
 @include oGridRespondTo(M) {
 	.article__title {
@@ -260,10 +228,6 @@ $inline-img-width: 300px;
 			line-height: 35px;
 		}
 	}
-	.article__img-inline,
-	.article__img-inline-offset {
-		max-width: $inline-img-width;
-	}
 }
 @include oGridRespondTo(L) {
 	.article__title {
@@ -271,8 +235,5 @@ $inline-img-width: 300px;
 	}
 	.article__mpu {
 		padding-top: 0;
-	}
-	.article__img-inline-offset {
-		margin-left: -$inline-img-width/2;
 	}
 }

--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -6,7 +6,7 @@ $inline-img-width: 300px;
 .article__header {
 	position: relative;
 	padding-bottom: $header-offset + 20;
-	background-color: #3b3e7f;
+	@include oColorsFor(ng-brand, background);
 	font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
 	font-weight: 100;
 	color: #ffffff;
@@ -163,8 +163,9 @@ $inline-img-width: 300px;
 
 	.back-top-top {
 		position: absolute;
-		top: 8px;
+		top: 50%;
 		right: 0;
+		margin-top: -10px;
 	}
 	.back-top-top__text {
 		position: absolute;
@@ -175,7 +176,7 @@ $inline-img-width: 300px;
 		background: url('/grumman/assets/img/back-to-top.svg') no-repeat;
 		background-size: contain;
 		width: 24px;
-		height: 21px;
+		height: 20px;
 	}
 }
 .article__big-number,
@@ -183,11 +184,6 @@ $inline-img-width: 300px;
 	width: 100%;
 	margin-top: 1.5em;
 	margin-bottom: 1.5em;
-}
-.article__big-number {
-	@include oGridRespondTo(L) {
-		@include oBigNumberStandardBig;
-	}
 }
 .article__pull-quote {
 	@include oGridRespondTo(L) {

--- a/client/main.scss
+++ b/client/main.scss
@@ -5,6 +5,7 @@ $o-big-number-is-silent: false;
 @import "o-forms/main";
 $o-gallery-is-silent: false;
 @import "o-gallery/main";
+@import "o-colors/main";
 
 @import "next-sass-setup/main";
 @import "next-header/main";
@@ -17,6 +18,7 @@ $o-gallery-is-silent: false;
 
 @import "_mixins";
 @import "_helpers";
+@import "_setup";
 @import "components/article/main";
 @import "components/more-on/main";
 @import "components/timeline/main";

--- a/client/main.scss
+++ b/client/main.scss
@@ -15,6 +15,8 @@ $o-gallery-is-silent: false;
 @import "next-barrier-component/client/main";
 @import "next-messaging/src/main";
 
+@import "_mixins";
+@import "_helpers";
 @import "components/article/main";
 @import "components/more-on/main";
 @import "components/timeline/main";

--- a/server/controllers/capi.js
+++ b/server/controllers/capi.js
@@ -76,7 +76,7 @@ module.exports = function(req, res, next) {
 					$('img').replaceWith(externalImgTransform);
 					$('ft-content').replaceWith(ftContentTransform);
 					$('p').replaceWith(pHackTransform);
-					$('blockquote').attr('class', 'o-quote o-quote--standard');
+					$('blockquote').attr('class', 'article__block-quote o-quote o-quote--standard');
 					$('pull-quote').replaceWith(pullQuotesTransform);
 
 					// HACK - Fix for paragraphs in blockquotes

--- a/server/transforms/big-number.js
+++ b/server/transforms/big-number.js
@@ -5,7 +5,7 @@ module.exports = function(index, el) {
 	el = $(el);
 	var title = el.find('big-number-headline').text();
 	var content = el.find('big-number-intro').text();
-	return '<span class="article__big-number ng-pull-out o-big-number o-big-number--standard"><span class="o-big-number__title">'
+	return '<span class="article__big-number ng-pull-out ng-inline-element o-big-number o-big-number--standard"><span class="o-big-number__title">'
 		+ title
 		+ '</span><span class="o-big-number__content">'
 		+ content

--- a/server/transforms/big-number.js
+++ b/server/transforms/big-number.js
@@ -5,7 +5,7 @@ module.exports = function(index, el) {
 	el = $(el);
 	var title = el.find('big-number-headline').text();
 	var content = el.find('big-number-intro').text();
-	return '<span class="o-big-number o-big-number--standard"><span class="o-big-number__title">'
+	return '<span class="g-pull-out g-inline-element o-big-number o-big-number--standard"><span class="o-big-number__title">'
 		+ title
 		+ '</span><span class="o-big-number__content">'
 		+ content

--- a/server/transforms/big-number.js
+++ b/server/transforms/big-number.js
@@ -5,7 +5,7 @@ module.exports = function(index, el) {
 	el = $(el);
 	var title = el.find('big-number-headline').text();
 	var content = el.find('big-number-intro').text();
-	return '<span class="g-pull-out g-inline-element o-big-number o-big-number--standard"><span class="o-big-number__title">'
+	return '<span class="article__big-number ng-pull-out o-big-number o-big-number--standard"><span class="o-big-number__title">'
 		+ title
 		+ '</span><span class="o-big-number__content">'
 		+ content

--- a/server/transforms/external-img.js
+++ b/server/transforms/external-img.js
@@ -4,6 +4,6 @@ var $ = require('cheerio');
 
 module.exports = function(index, el) {
 	el = $(el);
-	el.attr('class', 'article__inline-image');
+	el.addClass('article__inline-image g-inline-element g-pull-out');
 	return el.clone();
 };

--- a/server/transforms/external-img.js
+++ b/server/transforms/external-img.js
@@ -4,6 +4,6 @@ var $ = require('cheerio');
 
 module.exports = function(index, el) {
 	el = $(el);
-	el.addClass('article__inline-image g-inline-element g-pull-out');
+	el.addClass('article__inline-image ng-inline-element ng-pull-out');
 	return el.clone();
 };

--- a/server/transforms/ft-content.js
+++ b/server/transforms/ft-content.js
@@ -13,7 +13,7 @@ module.exports = function(index, originEl) {
 			if (originEl.parentNode.tagName === 'body' && $(originEl.parentNode).children().first().html() === el.html()) {
 				return '<img class="article__main-image" src="/embedded-components/image' + url + '"/ >';
 			}
-			return '<img class="article__inline-image" src="/embedded-components/image' + url + '"/ >';
+			return '<img class="article__inline-image g-inline-element g-pull-out" src="/embedded-components/image' + url + '"/ >';
 		case 'http://www.ft.com/ontology/content/Article':
 			return '<a href="' + url + '">' + text + '</a>';
 		default:

--- a/server/transforms/ft-content.js
+++ b/server/transforms/ft-content.js
@@ -13,7 +13,7 @@ module.exports = function(index, originEl) {
 			if (originEl.parentNode.tagName === 'body' && $(originEl.parentNode).children().first().html() === el.html()) {
 				return '<img class="article__main-image" src="/embedded-components/image' + url + '"/ >';
 			}
-			return '<img class="article__inline-image g-inline-element g-pull-out" src="/embedded-components/image' + url + '"/ >';
+			return '<img class="article__inline-image ng-inline-element ng-pull-out" src="/embedded-components/image' + url + '"/ >';
 		case 'http://www.ft.com/ontology/content/Article':
 			return '<a href="' + url + '">' + text + '</a>';
 		default:

--- a/server/transforms/pull-quotes.js
+++ b/server/transforms/pull-quotes.js
@@ -5,9 +5,8 @@ module.exports = function(index, el) {
 	el = $(el);
 	var text = el.find('pull-quote-text').text();
 	var cite = el.find('pull-quote-source').text();
-	return '<blockquote class="o-quote o-quote--standard-big"><p>'
-		+ text
-		+ '</p><cite class="o-quote__cite">'
-		+ cite
-		+ '</cite></blockquote>';
+	return '<blockquote class="article__pull-quote g-pull-out o-quote o-quote--standard">' +
+		'<p>' + text + '</p>' +
+		(cite ? '<cite class="o-quote__cite">' + cite + '</cite>' : '') +
+	'</blockquote>';
 };

--- a/server/transforms/pull-quotes.js
+++ b/server/transforms/pull-quotes.js
@@ -5,7 +5,7 @@ module.exports = function(index, el) {
 	el = $(el);
 	var text = el.find('pull-quote-text').text();
 	var cite = el.find('pull-quote-source').text();
-	return '<blockquote class="article__pull-quote g-pull-out o-quote o-quote--standard">' +
+	return '<blockquote class="article__pull-quote ng-pull-out o-quote o-quote--standard">' +
 		'<p>' + text + '</p>' +
 		(cite ? '<cite class="o-quote__cite">' + cite + '</cite>' : '') +
 	'</blockquote>';

--- a/server/transforms/subheaders.js
+++ b/server/transforms/subheaders.js
@@ -5,7 +5,7 @@ var $ = require('cheerio');
 module.exports = function(index, el) {
 	var $el = $(el);
 
-	$el.addClass('g-pull-out')
+	$el.addClass('article__subhead ng-pull-out')
 		.html('<span class="ft-subhead__title">' + $el.text() + '</span>')
 		.append('<a class="back-top-top" href="#top"><span class="back-top-top__text">Back to top</span><span class="back-top-top__icon" /></a>');
 

--- a/server/transforms/subheaders.js
+++ b/server/transforms/subheaders.js
@@ -5,7 +5,8 @@ var $ = require('cheerio');
 module.exports = function(index, el) {
 	var $el = $(el);
 
-	$el.html('<span class="ft-subhead__title">' + $el.text() + '</span>')
+	$el.addClass('g-pull-out')
+		.html('<span class="ft-subhead__title">' + $el.text() + '</span>')
 		.append('<a class="back-top-top" href="#top"><span class="back-top-top__text">Back to top</span><span class="back-top-top__icon" /></a>');
 
 	return $el.clone();

--- a/tests/server/big-number.test.js
+++ b/tests/server/big-number.test.js
@@ -7,5 +7,5 @@ var bigNumberTransform = require('../../server/transforms/big-number');
 it('should understand that topic pages are stream pages', function() {
 	var $ = cheerio.load('<big-number><big-number-headline>33m</big-number-headline><big-number-intro>These are powerful but fragile emissaries of a culture that not even their descendants remember</big-number-intro></big-number>');
 	$('big-number').replaceWith(bigNumberTransform);
-	expect($.html()).to.equal('<span class="article__big-number ng-pull-out o-big-number o-big-number--standard"><span class="o-big-number__title">33m</span><span class="o-big-number__content">These are powerful but fragile emissaries of a culture that not even their descendants remember</span></span>');
+	expect($.html()).to.equal('<span class="article__big-number ng-pull-out ng-inline-element o-big-number o-big-number--standard"><span class="o-big-number__title">33m</span><span class="o-big-number__content">These are powerful but fragile emissaries of a culture that not even their descendants remember</span></span>');
 });

--- a/tests/server/big-number.test.js
+++ b/tests/server/big-number.test.js
@@ -7,5 +7,5 @@ var bigNumberTransform = require('../../server/transforms/big-number');
 it('should understand that topic pages are stream pages', function() {
 	var $ = cheerio.load('<big-number><big-number-headline>33m</big-number-headline><big-number-intro>These are powerful but fragile emissaries of a culture that not even their descendants remember</big-number-intro></big-number>');
 	$('big-number').replaceWith(bigNumberTransform);
-	expect($.html()).to.equal('<span class="o-big-number o-big-number--standard"><span class="o-big-number__title">33m</span><span class="o-big-number__content">These are powerful but fragile emissaries of a culture that not even their descendants remember</span></span>');
+	expect($.html()).to.equal('<span class="g-pull-out g-inline-element o-big-number o-big-number--standard"><span class="o-big-number__title">33m</span><span class="o-big-number__content">These are powerful but fragile emissaries of a culture that not even their descendants remember</span></span>');
 });

--- a/tests/server/big-number.test.js
+++ b/tests/server/big-number.test.js
@@ -7,5 +7,5 @@ var bigNumberTransform = require('../../server/transforms/big-number');
 it('should understand that topic pages are stream pages', function() {
 	var $ = cheerio.load('<big-number><big-number-headline>33m</big-number-headline><big-number-intro>These are powerful but fragile emissaries of a culture that not even their descendants remember</big-number-intro></big-number>');
 	$('big-number').replaceWith(bigNumberTransform);
-	expect($.html()).to.equal('<span class="g-pull-out g-inline-element o-big-number o-big-number--standard"><span class="o-big-number__title">33m</span><span class="o-big-number__content">These are powerful but fragile emissaries of a culture that not even their descendants remember</span></span>');
+	expect($.html()).to.equal('<span class="article__big-number ng-pull-out o-big-number o-big-number--standard"><span class="o-big-number__title">33m</span><span class="o-big-number__content">These are powerful but fragile emissaries of a culture that not even their descendants remember</span></span>');
 });

--- a/tests/server/external-img.test.js
+++ b/tests/server/external-img.test.js
@@ -7,5 +7,5 @@ var externalImgTransform = require('../../server/transforms/external-img');
 it('should understand that topic pages are stream pages', function() {
 	var $ = cheerio.load('<p><img src="http://my-image/image.jpg"></img>Mr Dougan has been blamed by some leading shareholders for failing to grasp the extent of the change in the aftermath of the financial crisis.</p>');
 	$('img').replaceWith(externalImgTransform);
-	expect($.html()).to.equal('<p><img src="http://my-image/image.jpg" class="article__inline-image">Mr Dougan has been blamed by some leading shareholders for failing to grasp the extent of the change in the aftermath of the financial crisis.</p>');
+	expect($.html()).to.equal('<p><img src="http://my-image/image.jpg" class="article__inline-image g-inline-element g-pull-out">Mr Dougan has been blamed by some leading shareholders for failing to grasp the extent of the change in the aftermath of the financial crisis.</p>');
 });

--- a/tests/server/external-img.test.js
+++ b/tests/server/external-img.test.js
@@ -7,5 +7,5 @@ var externalImgTransform = require('../../server/transforms/external-img');
 it('should understand that topic pages are stream pages', function() {
 	var $ = cheerio.load('<p><img src="http://my-image/image.jpg"></img>Mr Dougan has been blamed by some leading shareholders for failing to grasp the extent of the change in the aftermath of the financial crisis.</p>');
 	$('img').replaceWith(externalImgTransform);
-	expect($.html()).to.equal('<p><img src="http://my-image/image.jpg" class="article__inline-image g-inline-element g-pull-out">Mr Dougan has been blamed by some leading shareholders for failing to grasp the extent of the change in the aftermath of the financial crisis.</p>');
+	expect($.html()).to.equal('<p><img src="http://my-image/image.jpg" class="article__inline-image ng-inline-element ng-pull-out">Mr Dougan has been blamed by some leading shareholders for failing to grasp the extent of the change in the aftermath of the financial crisis.</p>');
 });

--- a/tests/server/ft-content.test.js
+++ b/tests/server/ft-content.test.js
@@ -13,7 +13,7 @@ it('should turn capi v2 ft-content links into a tags', function() {
 it('should turn capi v2 ft-content image into img tags', function() {
 	var $ = cheerio.load('<p><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/4e2487ee-422b-11e4-39b2-97bbf262bf2b"></ft-content>Another left-aligned landscape image here.</p>');
 	$('ft-content').replaceWith(ftContentTransform);
-	expect($.html()).to.equal('<p><img class="article__inline-image g-inline-element g-pull-out" src="/embedded-components/image/4e2487ee-422b-11e4-39b2-97bbf262bf2b">Another left-aligned landscape image here.</p>');
+	expect($.html()).to.equal('<p><img class="article__inline-image ng-inline-element ng-pull-out" src="/embedded-components/image/4e2487ee-422b-11e4-39b2-97bbf262bf2b">Another left-aligned landscape image here.</p>');
 });
 
 it('should turn capi v2 ft-content unrecognised content types into nothing', function() {
@@ -37,5 +37,5 @@ it('should promote main images to main images', function() {
 it('should not promote not main images to main images', function() {
 	var $ = cheerio.load('<body><p>First paragraph</p><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/12395166-c6cd-11e4-3f5b-978e959e1c97"></ft-content><p>Tim says “aluminum”, Jony says “aluminium”.</p></body>');
 	$('ft-content').replaceWith(ftContentTransform);
-	expect($.html()).to.equal('<body><p>First paragraph</p><img class="article__inline-image g-inline-element g-pull-out" src="/embedded-components/image/12395166-c6cd-11e4-3f5b-978e959e1c97"><p>Tim says &#x201C;aluminum&#x201D;, Jony says &#x201C;aluminium&#x201D;.</p></body>');
+	expect($.html()).to.equal('<body><p>First paragraph</p><img class="article__inline-image ng-inline-element ng-pull-out" src="/embedded-components/image/12395166-c6cd-11e4-3f5b-978e959e1c97"><p>Tim says &#x201C;aluminum&#x201D;, Jony says &#x201C;aluminium&#x201D;.</p></body>');
 });

--- a/tests/server/ft-content.test.js
+++ b/tests/server/ft-content.test.js
@@ -13,7 +13,7 @@ it('should turn capi v2 ft-content links into a tags', function() {
 it('should turn capi v2 ft-content image into img tags', function() {
 	var $ = cheerio.load('<p><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/4e2487ee-422b-11e4-39b2-97bbf262bf2b"></ft-content>Another left-aligned landscape image here.</p>');
 	$('ft-content').replaceWith(ftContentTransform);
-	expect($.html()).to.equal('<p><img class="article__inline-image" src="/embedded-components/image/4e2487ee-422b-11e4-39b2-97bbf262bf2b">Another left-aligned landscape image here.</p>');
+	expect($.html()).to.equal('<p><img class="article__inline-image g-inline-element g-pull-out" src="/embedded-components/image/4e2487ee-422b-11e4-39b2-97bbf262bf2b">Another left-aligned landscape image here.</p>');
 });
 
 it('should turn capi v2 ft-content unrecognised content types into nothing', function() {
@@ -31,11 +31,11 @@ it('should turn capi v2 ft-content links with pretty content into pretty links',
 it('should promote main images to main images', function() {
 	var $ = cheerio.load('<body><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/12395166-c6cd-11e4-3f5b-978e959e1c97"></ft-content><p>Tim says “aluminum”, Jony says “aluminium”.</p></body>');
 	$('ft-content').replaceWith(ftContentTransform);
-	expect($.html()).to.equal('<body><img class=\"article__main-image\" src=\"/embedded-components/image/12395166-c6cd-11e4-3f5b-978e959e1c97\"><p>Tim says &#x201C;aluminum&#x201D;, Jony says &#x201C;aluminium&#x201D;.</p></body>');
+	expect($.html()).to.equal('<body><img class="article__main-image" src="/embedded-components/image/12395166-c6cd-11e4-3f5b-978e959e1c97"><p>Tim says &#x201C;aluminum&#x201D;, Jony says &#x201C;aluminium&#x201D;.</p></body>');
 });
 
 it('should not promote not main images to main images', function() {
 	var $ = cheerio.load('<body><p>First paragraph</p><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/12395166-c6cd-11e4-3f5b-978e959e1c97"></ft-content><p>Tim says “aluminum”, Jony says “aluminium”.</p></body>');
 	$('ft-content').replaceWith(ftContentTransform);
-	expect($.html()).to.equal('<body><p>First paragraph</p><img class=\"article__inline-image\" src=\"/embedded-components/image/12395166-c6cd-11e4-3f5b-978e959e1c97\"><p>Tim says &#x201C;aluminum&#x201D;, Jony says &#x201C;aluminium&#x201D;.</p></body>');
+	expect($.html()).to.equal('<body><p>First paragraph</p><img class="article__inline-image g-inline-element g-pull-out" src="/embedded-components/image/12395166-c6cd-11e4-3f5b-978e959e1c97"><p>Tim says &#x201C;aluminum&#x201D;, Jony says &#x201C;aluminium&#x201D;.</p></body>');
 });

--- a/tests/server/pull-quote.test.js
+++ b/tests/server/pull-quote.test.js
@@ -8,12 +8,12 @@ it('should turn capi v2 pull-quotes into o-quotes', function() {
 	var $ = cheerio.load('<pull-quote><pull-quote-text>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</pull-quote-text><pull-quote-source>Dr. Seuss</pull-quote-source></pull-quote>');
 	$('pull-quote').replaceWith(pullQuotesTransform);
 
-	expect($.html()).to.equal('<blockquote class="article__pull-quote g-pull-out o-quote o-quote--standard"><p>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</p><cite class="o-quote__cite">Dr. Seuss</cite></blockquote>');
+	expect($.html()).to.equal('<blockquote class="article__pull-quote ng-pull-out o-quote o-quote--standard"><p>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</p><cite class="o-quote__cite">Dr. Seuss</cite></blockquote>');
 });
 
 it('should not include citation if non available', function() {
 	var $ = cheerio.load('<pull-quote><pull-quote-text>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</pull-quote-text><pull-quote-source></pull-quote-source></pull-quote>');
 	$('pull-quote').replaceWith(pullQuotesTransform);
 
-	expect($.html()).to.equal('<blockquote class="article__pull-quote g-pull-out o-quote o-quote--standard"><p>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</p></blockquote>');
+	expect($.html()).to.equal('<blockquote class="article__pull-quote ng-pull-out o-quote o-quote--standard"><p>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</p></blockquote>');
 });

--- a/tests/server/pull-quote.test.js
+++ b/tests/server/pull-quote.test.js
@@ -8,5 +8,12 @@ it('should turn capi v2 pull-quotes into o-quotes', function() {
 	var $ = cheerio.load('<pull-quote><pull-quote-text>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</pull-quote-text><pull-quote-source>Dr. Seuss</pull-quote-source></pull-quote>');
 	$('pull-quote').replaceWith(pullQuotesTransform);
 
-	expect($.html()).to.equal('<blockquote class="o-quote o-quote--standard-big"><p>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</p><cite class="o-quote__cite">Dr. Seuss</cite></blockquote>');
+	expect($.html()).to.equal('<blockquote class="article__pull-quote g-pull-out o-quote o-quote--standard"><p>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</p><cite class="o-quote__cite">Dr. Seuss</cite></blockquote>');
+});
+
+it('should not include citation if non available', function() {
+	var $ = cheerio.load('<pull-quote><pull-quote-text>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</pull-quote-text><pull-quote-source></pull-quote-source></pull-quote>');
+	$('pull-quote').replaceWith(pullQuotesTransform);
+
+	expect($.html()).to.equal('<blockquote class="article__pull-quote g-pull-out o-quote o-quote--standard"><p>Think left and think right and think low and think high. Oh, the thinks you can think up if only you try!</p></blockquote>');
 });

--- a/tests/server/subheaders.test.js
+++ b/tests/server/subheaders.test.js
@@ -10,7 +10,7 @@ it('should update subheaders', function() {
 	$('.ft-subhead').replaceWith(subheadersTransform);
 
 	expect($.html()).to.equal(
-		'<h3 class="ft-subhead g-pull-out">' +
+		'<h3 class="ft-subhead article__subhead ng-pull-out">' +
 			'<span class="ft-subhead__title">The new big earners</span>' +
 			'<a class="back-top-top" href="#top">' +
 				'<span class="back-top-top__text">Back to top</span>' +

--- a/tests/server/subheaders.test.js
+++ b/tests/server/subheaders.test.js
@@ -1,0 +1,21 @@
+/*global it*/
+'use strict';
+
+var cheerio = require('cheerio');
+var expect = require('chai').expect;
+var subheadersTransform = require('../../server/transforms/subheaders');
+
+it('should update subheaders', function() {
+	var $ = cheerio.load('<h3 class="ft-subhead">The new big earners</h3>');
+	$('.ft-subhead').replaceWith(subheadersTransform);
+
+	expect($.html()).to.equal(
+		'<h3 class="ft-subhead g-pull-out">' +
+			'<span class="ft-subhead__title">The new big earners</span>' +
+			'<a class="back-top-top" href="#top">' +
+				'<span class="back-top-top__text">Back to top</span>' +
+				'<span class="back-top-top__icon"></span>' +
+			'</a>' +
+		'</h3>'
+	);
+});

--- a/views/layout.html
+++ b/views/layout.html
@@ -15,8 +15,6 @@
 			{{/with}}
 			<div data-o-grid-colspan="12 L8 XL7 XLoffset2">
 				<h3 class="article__title">{{{article.titleHTML}}}</h3>
-			</div>
-			<div data-o-grid-colspan="12 L4 XL3">
 				<h4 class="article__stand-first">{{{articleV1.editorial.standFirst}}}</h4>
 			</div>
 			<div data-o-grid-colspan="12 L8 XL7 XLoffset2">


### PR DESCRIPTION
use latest origami pull quotes and big number, tidy up/remove unused classes

also, now have a `ng-pull-out` for pulled-out elements, and `ng-inline-element` for, er, inline elements

![screen shot 2015-03-11 at 16 09 20](https://cloud.githubusercontent.com/assets/74132/6600696/00bafeb6-c809-11e4-8124-a8ae1c110c0e.jpeg)
