### PR TITLE
General page fixes

### DIFF
--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -103,6 +103,9 @@ $header-offset: 30px;
 	font-family: oFontsGetFontFamilyWithFallbacks(MetricWeb);
 }
 
+.article__main {
+	padding-top: 15px;
+}
 
 //ARTICLE BODY ELEMENTS
 .article__body {
@@ -115,6 +118,9 @@ $header-offset: 30px;
 		line-height: 24px;
 		display: block;
 	}
+	> .article__main-image:first-child + ft-paragraph {
+		margin-top: 0;
+	}
 
 	a {
 		color: $next-grey-dark;
@@ -126,14 +132,14 @@ $header-offset: 30px;
 	> {
 		.article__video:first-child,
 		.article__gallery:first-child {
-			margin-top: -$header-offset;
+			margin-top: -$header-offset - 15;
 		}
 	}
 }
 
 .article__main-image {
 	width: 100%;
-	margin-top: 10px;
+	margin-top: 0;
 }
 .article__mpu {
 	text-align: center;
@@ -176,10 +182,6 @@ $header-offset: 30px;
 	@include oGridRespondTo(L) {
 		@include oQuoteStandardBig;
 	}
-}
-
-.article__rail-advert {
-	margin-top: 17px;
 }
 
 //++++++++++++++++++++++++++

--- a/client/components/article/main.scss
+++ b/client/components/article/main.scss
@@ -125,6 +125,9 @@ $header-offset: 30px;
 	a {
 		color: $next-grey-dark;
 	}
+	.o-quote--standard a {
+		color: inherit;
+	}
 
 	video {
 		width: 100%;

--- a/client/components/related/_main.scss
+++ b/client/components/related/_main.scss
@@ -12,6 +12,10 @@
 	position: relative;
 	margin: 0;
 }
+.article__related__title,
+.article__related__timestamp {
+	opacity: 0.7;
+}
 .article__related__title {
 	font-size: 16px;
 	line-height: 1em;

--- a/server/transforms/p-strongs-to-h3s.js
+++ b/server/transforms/p-strongs-to-h3s.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = function(body) {
-	return body.replace(/<p>\s*<strong>(.*?)<\/strong>\s*<\/p>/g, '<h3 class="ft-subhead">$1</h3>');
+	return body.replace(/<p>\s*<strong>([^<]+?)<\/strong>\s*<\/p>/g, '<h3 class="ft-subhead">$1</h3>');
 };

--- a/server/transforms/trimmed-links.js
+++ b/server/transforms/trimmed-links.js
@@ -6,14 +6,16 @@ module.exports = function(index, el) {
 	var matches;
 	var contents = el.html()
 		.replace("\n", " ")
+		.replace('&#x2018;', '‘')
+		.replace('&#x2019;', '’')
 		.replace('&#x201C;', '“')
 		.replace('&#x201D;', '”');
 
-	var quoteReg = /^“ ?(.*) ?”$/;
+	var quoteReg = /^([“‘]) ?(.*) ?([”’])$/;
 	matches = quoteReg.exec(contents);
 	if (matches) {
-		el.html(matches[1]);
-		return '“' + $.html(el) + '”';
+		el.html(matches[2]);
+		return matches[1] + $.html(el) + matches[3];
 	}
 
 	var trailingReg = /([ ,.;:]\s*)$/m;

--- a/tests/server/p-strongs-to-h3s.test.js
+++ b/tests/server/p-strongs-to-h3s.test.js
@@ -13,3 +13,8 @@ it('should convert multiple occurrences', function() {
 	var transformed = pStrongsToH3s('<p><strong>London in a world of its own</strong></p><p><strong>Paying a heavy price</strong></p>');
 	expect(transformed).to.equal('<h3 class="ft-subhead">London in a world of its own</h3><h3 class="ft-subhead">Paying a heavy price</h3>');
 });
+
+it('should not convert if empty', function() {
+	var transformed = pStrongsToH3s('<p><strong></strong>Paying a heavy price</p>');
+	expect(transformed).to.equal('<p><strong></strong>Paying a heavy price</p>');
+});

--- a/views/layout.html
+++ b/views/layout.html
@@ -14,7 +14,9 @@
 				<h3 class="article__title">{{{article.titleHTML}}}</h3>
 				{{! TODO: Update to CAPI v2 when this is available ~end of Q1 }}
 				{{! Probably something like article.summaries[0] }}
-				<h4 class="article__stand-first">{{{articleV1.editorial.standFirst}}}</h4>
+				{{#if articleV1.editorial.standFirst}}
+					<h4 class="article__stand-first">{{{articleV1.editorial.standFirst}}}</h4>
+				{{/if}}
 			</div>
 			<div data-o-grid-colspan="12 L8 XL7 XLoffset2">
 				<div class="article__meta">


### PR DESCRIPTION
This monstrosity - http://next.ft.com/11bd3a2f-975a-3d90-b6cf-e2d81fde08ff - raised a few issues

 * handle multiple `p`s in a `blockquote`
 * handle single quotes in links when trimming
 * handle empty `strong` in `p` (when converting to a subheader)