### PR TITLE
Correct asset building when in prod

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,27 +8,32 @@ var obt = require('origami-build-tools');
 var extractSourceMap = require('next-gulp-tasks').extractSourceMap;
 var minify = require('next-gulp-tasks').minify;
 var getOBTConfig = require('next-gulp-tasks').getOBTConfig;
+// to be safe, default to production
+var env = process.env.ENVIRONMENT || 'production';
 
 var mainJsFile = './public/main.js';
 
 gulp.task('build-js', function () {
-	return obt.build.js(gulp, getOBTConfig(process.env.ENVIRONMENT || 'development'))
+	// need to run as development, or can't get sourcemaps
+	return obt.build.js(gulp, getOBTConfig('development'))
 		.pipe(notify('Grumman JS built'));
 });
 
 gulp.task('build-sass', function(){
-	return obt.build.sass(gulp, getOBTConfig(process.env.ENVIRONMENT || 'production'))
+	return obt.build.sass(gulp, getOBTConfig(env))
 		.pipe(notify('Grumman Sass built'));
 });
 
 gulp.task('build', ['build-js', 'build-sass']);
 
 gulp.task('minify-js',['build-js'], function(){
-	var sourceMapFile = './public/main.js.map';
-	return gulp.src(mainJsFile)
-		.pipe(extractSourceMap({saveTo:sourceMapFile}))
-		.pipe(minify({sourceMapIn:sourceMapFile,sourceMapOut:'/grumman/main.js.map'}))
-		.pipe(gulp.dest('./public/'));
+	if (env === 'production') {
+		var sourceMapFile = './public/main.js.map';
+		return gulp.src(mainJsFile)
+			.pipe(extractSourceMap({saveTo:sourceMapFile}))
+			.pipe(minify({sourceMapIn:sourceMapFile,sourceMapOut:'/grumman/main.js.map'}))
+			.pipe(gulp.dest('./public/'));
+	}
 });
 
 


### PR DESCRIPTION
Building JS was failing if `ENVIRONMENT` was prod, due to obt stripping out the sourcemap comment

Also, no need to minify/create external source map if in dev