### PR TITLE
deal with errors triggered in sentry

### DIFF
--- a/server/utils/catch-network-errors.js
+++ b/server/utils/catch-network-errors.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function(err) {
+	if (err.message.indexOf('network timeout at') > -1) {
+		console.log("Fetch network error occurred");
+		console.warn(err.message);
+		// temporarily set a big status until this change rolls out everywhere:-
+		// https://github.com/matthew-andrews/fetchres/pull/3
+		return { ok: false, status: 9999 };
+	} else {
+		throw err;
+	}
+};

--- a/server/utils/fetch-capi-v1.js
+++ b/server/utils/fetch-capi-v1.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var fetchres = require('fetchres');
+var catchNetworkErrors = require('./catch-network-errors');
 
 module.exports = function(opts) {
 	var uuid = opts.uuid;
@@ -26,6 +27,7 @@ module.exports = function(opts) {
 				'X-Api-Key': process.env.apikey
 			}
 		})
+			.catch(catchNetworkErrors)
 			.then(function(response) {
 				if (!response.ok) {
 					console.log("Got " + response.status + " for capi v1 uuid " + uuid);

--- a/server/utils/fetch-capi-v2.js
+++ b/server/utils/fetch-capi-v2.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var fetchres = require('fetchres');
+var catchNetworkErrors = require('./catch-network-errors');
 
 module.exports = function(opts) {
 	var uuid = opts.uuid;
@@ -13,6 +14,7 @@ module.exports = function(opts) {
 				'X-Api-Key': process.env.api2key
 			}
 		})
+			.catch(catchNetworkErrors)
 			.then(function(response) {
 				if (!response.ok) {
 					console.log("Got " + response.status + " for capi v2 uuid " + uuid);

--- a/server/utils/fetch-sapi-v1.js
+++ b/server/utils/fetch-sapi-v1.js
@@ -3,6 +3,7 @@
 
 var fetchres = require('fetchres');
 var fetchCapiV2 = require('./fetch-capi-v2');
+var catchNetworkErrors = require('./catch-network-errors');
 
 module.exports = function(opts) {
 	var query = opts.query;
@@ -32,6 +33,7 @@ module.exports = function(opts) {
 				'X-Api-Key': process.env.apikey
 			}
 		})
+			.catch(catchNetworkErrors)
 			.then(function(response) {
 				if (!response.ok) {
 					console.log("Got " + response.status + " for sapi v1 query " + query);


### PR DESCRIPTION
So this is slightly awkward…

Working on a better fix in node-fetch itself — https://github.com/bitinn/node-fetch/issues/7

Probably make it so that `fetchres` throws `FetchError`s so that our code can go back to how it was.

For now though here's a hack.

@ironsidevsquincy 