### PR TITLE
Tags should display correctly in a shallow header

### DIFF
--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -14,7 +14,7 @@ $header-offset: 30px;
 	color: #ffffff;
 }
 .article__header-inner {
-	position: relative;
+	display: flex;
 }
 .article__header--overlap {
 	padding-bottom: $header-offset + 20;
@@ -108,9 +108,7 @@ $header-offset: 30px;
 	top: 2px;
 }
 .article__tags {
-	position: absolute;
-	right: 0;
-	bottom: 0;
+	align-self: flex-end;
 	font-size: 18px;
 	font-weight: normal;
 }


### PR DESCRIPTION
flex ftw

### Before

![screen shot 2015-04-16 at 10 31 40](https://cloud.githubusercontent.com/assets/74132/7178078/e154dd76-e423-11e4-8cf4-ee3984caa53c.jpeg)

### After

![screen shot 2015-04-16 at 10 31 43](https://cloud.githubusercontent.com/assets/74132/7178080/e4b1a2b0-e423-11e4-96d4-9a6939b25fe4.jpeg)

resolves https://github.com/Financial-Times/next-grumman/issues/388